### PR TITLE
Set C standard to gnu11 for successful compilation on older compiler …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -g
+CFLAGS = -Wall -g -std=gnu11
 
 BIN = nuke
 


### PR DESCRIPTION
Adds -std=gnu11 so that the code can be compiled with older compilers without any user action. Fixes #4 