### PR TITLE
Bug fix for make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -g -std=gnu11
 
+INSTALL_PATH = /usr/local/bin
 BIN = nuke
 
 OBJS = $(patsubst src/%.c,src/%.o,$(wildcard src/*.c))
@@ -19,6 +20,13 @@ src/%.o: src/%.c src/%.h
 gui ui: $(BIN)
 	pyuic5 -x $(UI) -o $(PY)
 
+install:
+	install -m 755 $(BIN) $(INSTALL_PATH)/$(BIN)
+
+uninstall:
+	rm -f $(INSTALL_PATH)/$(BIN)
+
 clean:
+	rm -f $(BIN)
 	rm -f src/*.o
 	rm -f $(PY)

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Run `sudo make install` to make and install Nuke.
 
 ## Uninstall
 
-Run `sudo make uninstall` to make and install Nuke.
+Run `sudo make uninstall` to make and uninstall Nuke.

--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Run `sudo make install` to make and install Nuke.
 
 ## Uninstall
 
-Run `sudo make uninstall` to make and uninstall Nuke.
+Run `sudo make uninstall` to uninstall Nuke.

--- a/README.md
+++ b/README.md
@@ -45,4 +45,8 @@ NOTE: At the moment, Nuke can only be installed and run on Linux.
 
 ## Install
 
-Run `make install` to make and install Nuke.
+Run `sudo make install` to make and install Nuke.
+
+## Uninstall
+
+Run `sudo make uninstall` to make and install Nuke.


### PR DESCRIPTION
Adds `make install` and `make uninstall` recipes to the Makefile and also updates the readme file accordingly. The nuke binary will be copied to `/usr/local/bin` , therefore needs `sudo make install`. 

Fixes #6 